### PR TITLE
Python 3 support and requirements.txt

### DIFF
--- a/netgraph.py
+++ b/netgraph.py
@@ -513,7 +513,8 @@ def draw_edges(adjacency_matrix,
         edge_color = edge_color.reshape([number_of_nodes, number_of_nodes, 4])
 
     sources, targets = np.where(~np.isnan(adjacency_matrix))
-    edge_list = zip(sources.tolist(), targets.tolist())
+    # Force into a list, since zip became a generator in Pytohn 3, and thus can't be indexed below
+    edge_list = list(zip(sources.tolist(), targets.tolist()))
 
     # order if necessary
     if edge_zorder is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+matplotlib >= 1.5


### PR DESCRIPTION
In python 3 the `zip`-functions returns a generator, so the code crashes when indexing is attempted into the generator. The zip call is not forced to evaluate to a list, and the change shouldn't affect python 2.

I also added a requirements.txt file.

Tested using Python 3.6 and Matplotlib 2.
