### PR TITLE
Compatibility to Numpy 1.10 and later - Fixed TypeError on true_division

### DIFF
--- a/netgraph/_main.py
+++ b/netgraph/_main.py
@@ -291,7 +291,7 @@ def get_color(mydict, cmap='RdGy', vmin=None, vmax=None):
     """
 
     keys = mydict.keys()
-    values = np.array(list(mydict.values()))
+    values = np.array(list(mydict.values()), dtype=np.float64)
 
     # apply edge_vmin, edge_vmax
     if vmin:


### PR DESCRIPTION
Fixing #9 by initializing the `values` array as `float64` from start. 