### PR TITLE
Update _main.py

### DIFF
--- a/netgraph/_main.py
+++ b/netgraph/_main.py
@@ -554,7 +554,11 @@ class BaseGraph(object):
     def _initialize_axis(self, ax):
         if ax is None:
             return plt.gca()
-        elif isinstance(ax, mpl.axes._subplots.Axes):
+        # elif isinstance(ax, mpl.axes._subplots.Axes):  <-- Original line.
+        # speedsmith 2023.02.26 Seems that _subplots was removed in a prior matplotlib release.
+        # Axes seems to have been moved. I am not sure if this change is correct or will cause other problems, 
+        # but it did allow the demo code to run.
+        elif isinstance(ax, mpl.axes.Axes):
             return ax
         else:
             raise TypeError(f"Variable 'ax' either None or a matplotlib axis instance. However, type(ax) is {type(ax)}.")


### PR DESCRIPTION
The _subplots class seems to have been removed from matplotlib version 3.7 or earlier. The change made here to _main.py avoids an error that crashes the original author's demo code (below) from the Quickstart under the comment "# Netgraph uses matplotlib for creating the visualisation." Running this demo code with the original _main.py caused the error: 

AttributeError: module 'matplotlib.axes' has no attribute '_subplots'
-----------------------------------------------------------------------

Minimum Reproducible Example:

```python
import matplotlib.pyplot as plt
from netgraph import Graph, InteractiveGraph, EditableGraph

# Several graph formats are supported:

# Netgraph uses matplotlib for creating the visualisation.
# Node and edge artistis are derived from `matplotlib.patches.PathPatch`.
# Node and edge labels are `matplotlib.text.Text` instances.
# Standard matplotlib syntax applies.
fig, ax = plt.subplots(figsize=(5, 4))
plot_instance = Graph([(0, 1)], node_labels=True, edge_labels=True, ax=ax)
plot_instance.node_artists[0].set_alpha(0.2)
plot_instance.edge_artists[(0, 1)].set_facecolor('red')
plot_instance.edge_label_artists[(0, 1)].set_style('italic')
plot_instance.node_label_artists[1].set_size(10)
ax.set_title("This is my fancy title.")
ax.set_facecolor('honeydew') # change background color
fig.canvas.draw()  # force redraw to display changes
fig.savefig('test.pdf', dpi=300)
plt.show()
```