### PR TITLE
correct the docstring parameter names to be the same as the variable names

### DIFF
--- a/netgraph/_node_layout.py
+++ b/netgraph/_node_layout.py
@@ -1696,7 +1696,7 @@ def get_geometric_layout(edges, edge_length, node_size=0., tol=1e-3, origin=(0, 
         Size (radius) of nodes.
         Providing the correct node size minimises the overlap of nodes in the graph,
         which can otherwise occur if there are many nodes, or if the nodes differ considerably in size.
-    tolerance : float, default 1e-3
+    tol : float, default 1e-3
         The tolerance of the cost function. Small values increase the accuracy, large values improve the computation time.
     origin : tuple, default (0, 0)
         The (float x, float y) coordinates corresponding to the lower left hand corner of the bounding box specifying the extent of the canvas.

--- a/netgraph/_node_layout.py
+++ b/netgraph/_node_layout.py
@@ -1690,7 +1690,7 @@ def get_geometric_layout(edges, edge_length, node_size=0., tol=1e-3, origin=(0, 
     ----------
     edges : list
         The edges of the graph, with each edge being represented by a (source node ID, target node ID) tuple.
-    edge_lengths : dict
+    edge_length : dict
         Mapping of edges to their lengths.
     node_size : scalar or dict, default 0.
         Size (radius) of nodes.


### PR DESCRIPTION
- The actual parameter name is `edge_length` but the dosctring had `edge_lengths`
(maybe instead should rename the variable `edge_length` to `edge_lengths`? - but then it should be renamed everywhere)
- corrected `tol` in the docstring. It was `tolerance`